### PR TITLE
GCW-3459 Change MainTabs Route wrapper from Switch to IonRouterOutlet

### DIFF
--- a/src/__tests__/integration/authentication-flow.test.tsx
+++ b/src/__tests__/integration/authentication-flow.test.tsx
@@ -1,21 +1,34 @@
 import React from "react";
 import { render, screen } from "@testing-library/react";
-import App from "App";
 import { expectToBeOnPage } from "test-utils/matchers";
 import userEvent, { TargetElement } from "@testing-library/user-event";
+import { IonApp } from "@ionic/react";
+import AuthProvider from "components/AuthProvider/AuthProvider";
+import { createMemoryHistory } from "history";
+import { Router } from "react-router";
+import MainRouter from "components/MainRouter/MainRouter";
 
 test("User is able to login and logout with correct routing", () => {
-  const { container } = render(<App />);
+  const history = createMemoryHistory({ initialEntries: ["/login"] });
+  const { container } = render(
+    <IonApp>
+      <AuthProvider>
+        <Router history={history}>
+          <MainRouter />
+        </Router>
+      </AuthProvider>
+    </IonApp>
+  );
 
-  expectToBeOnPage(container, window.location.pathname, "login");
+  expectToBeOnPage(container, history.location.pathname, "login");
 
   const loginButton = container.querySelector("ion-button");
   userEvent.click(loginButton as TargetElement);
 
-  expectToBeOnPage(container, window.location.pathname, "home");
+  expectToBeOnPage(container, history.location.pathname, "home");
 
   const logoutButton = screen.getByText(/log out/i);
   userEvent.click(logoutButton as TargetElement);
 
-  expectToBeOnPage(container, window.location.pathname, "login");
+  expectToBeOnPage(container, history.location.pathname, "login");
 });

--- a/src/components/MainTabs/MainTabs.test.tsx
+++ b/src/components/MainTabs/MainTabs.test.tsx
@@ -1,18 +1,18 @@
 import React from "react";
 import { render } from "@testing-library/react";
 import MainTabs from "components/MainTabs/MainTabs";
-import { IonReactRouter } from "@ionic/react-router";
 import { expectToBeOnPage } from "test-utils/matchers";
 import { createMemoryHistory } from "history";
+import { Router } from "react-router";
 
 const renderComponent = (initialPath: string) => {
   const history = createMemoryHistory({ initialEntries: [initialPath] });
   return {
     history,
     ...render(
-      <IonReactRouter history={history}>
+      <Router history={history}>
         <MainTabs />
-      </IonReactRouter>
+      </Router>
     ),
   };
 };

--- a/src/components/MainTabs/MainTabs.tsx
+++ b/src/components/MainTabs/MainTabs.tsx
@@ -1,17 +1,18 @@
 import React from "react";
 import Home from "pages/Home/Home";
 import Offers from "pages/Offers/Offers";
-import { Route, Switch } from "react-router";
+import { Route } from "react-router";
+import { IonRouterOutlet } from "@ionic/react";
 
 const MainTabs = () => (
-  <Switch>
+  <IonRouterOutlet>
     <Route exact path="/offers">
       <Offers />
     </Route>
     <Route exact path="/home">
       <Home />
     </Route>
-  </Switch>
+  </IonRouterOutlet>
 );
 
 export default MainTabs;


### PR DESCRIPTION
## Ticket Link
https://jira.crossroads.org.hk/browse/GCW-3459
## What does this PR do?
IonRouterOutlet is required for creating Tab layouts.
This PR also updates tests to use `Router` instead of `IonReactRouter`, as `IonReactRouter` paired with `IonRouterOutlet` has issues rendering on JSDOM.