### PR TITLE
GCW-3479 Store otp_auth_token in persistent storage

### DIFF
--- a/src/__tests__/integration/authentication-flow.test.tsx
+++ b/src/__tests__/integration/authentication-flow.test.tsx
@@ -8,6 +8,7 @@ import { createMemoryHistory } from "history";
 import { Router } from "react-router";
 import MainRouter from "components/MainRouter/MainRouter";
 import client from "lib/client/client";
+import { OTP_AUTH_KEY } from "test-utils/config/localStorageKeys";
 
 let mockPost: jest.SpyInstance;
 beforeAll(
@@ -16,6 +17,7 @@ beforeAll(
       .spyOn(client, "post")
       .mockResolvedValue({ otp_auth_key: "sdfdsfdsaf" }))
 );
+afterEach(() => localStorage.removeItem(OTP_AUTH_KEY));
 afterAll(() => mockPost.mockRestore());
 
 test("User is able to login and logout with correct routing", async () => {

--- a/src/components/AuthProvider/AuthProvider.test.tsx
+++ b/src/components/AuthProvider/AuthProvider.test.tsx
@@ -1,5 +1,5 @@
 import { computeAuthState } from "components/AuthProvider/AuthProvider";
-import { GC_API_TOKEN } from "config/localStorageKeys";
+import { GC_API_TOKEN } from "test-utils/config/localStorageKeys";
 
 afterEach(() => localStorage.removeItem(GC_API_TOKEN));
 

--- a/src/config/localStorageKeys.ts
+++ b/src/config/localStorageKeys.ts
@@ -1,3 +1,4 @@
 const GC_API_TOKEN = "gc_api_token";
+const OTP_AUTH_KEY = "otp_auth_key";
 
-export { GC_API_TOKEN };
+export { GC_API_TOKEN, OTP_AUTH_KEY };

--- a/src/hooks/useAuth/useAuth.test.tsx
+++ b/src/hooks/useAuth/useAuth.test.tsx
@@ -2,8 +2,7 @@ import React from "react";
 import useAuth, { Auth } from "hooks/useAuth/useAuth";
 import { render, cleanup, act } from "@testing-library/react";
 import AuthProvider from "components/AuthProvider/AuthProvider";
-
-const GC_API_TOKEN = "gc_api_token";
+import { GC_API_TOKEN } from "test-utils/config/localStorageKeys";
 
 const setup = (Wrapper: React.FC) => {
   let auth: Auth | {} = {};

--- a/src/lib/services/AuthenticationService/AuthenticationService.test.ts
+++ b/src/lib/services/AuthenticationService/AuthenticationService.test.ts
@@ -1,6 +1,6 @@
 import client from "lib/client/client";
 import AuthenticationService from "lib/services/AuthenticationService/AuthenticationService";
-import { OTP_AUTH_KEY } from "config/localStorageKeys";
+import { OTP_AUTH_KEY } from "test-utils/config/localStorageKeys";
 
 let mockPost: jest.SpyInstance;
 beforeAll(() => (mockPost = jest.spyOn(client, "post")));

--- a/src/lib/services/AuthenticationService/AuthenticationService.test.ts
+++ b/src/lib/services/AuthenticationService/AuthenticationService.test.ts
@@ -26,6 +26,7 @@ describe("sendPin", () => {
   });
 
   it("should store received token in localStorage", async () => {
+    expect(localStorage.getItem(OTP_AUTH_KEY)).toBeNull();
     await AuthenticationService.sendPin({ mobile });
     expect(localStorage.getItem(OTP_AUTH_KEY)).toBe(otpAuthKey);
   });

--- a/src/lib/services/AuthenticationService/AuthenticationService.ts
+++ b/src/lib/services/AuthenticationService/AuthenticationService.ts
@@ -1,3 +1,4 @@
+import { OTP_AUTH_KEY } from "config/localStorageKeys";
 import client from "lib/client/client";
 
 interface SendPinBody {
@@ -6,8 +7,9 @@ interface SendPinBody {
 interface SendPinResponse {
   otp_auth_key: string;
 }
-function sendPin(body: SendPinBody): Promise<SendPinResponse> {
-  return client.post("auth/send_pin", body);
+async function sendPin(body: SendPinBody): Promise<void> {
+  const response: SendPinResponse = await client.post("auth/send_pin", body);
+  localStorage.setItem(OTP_AUTH_KEY, response.otp_auth_key);
 }
 
 interface VerifyBody {

--- a/src/lib/services/AuthenticationService/AuthenticationService.ts
+++ b/src/lib/services/AuthenticationService/AuthenticationService.ts
@@ -1,24 +1,17 @@
 import { OTP_AUTH_KEY } from "config/localStorageKeys";
 import client from "lib/client/client";
+import {
+  SendPinBody,
+  SendPinResponse,
+  VerifyBody,
+  VerifyResponse,
+} from "lib/services/AuthenticationService/types";
 
-interface SendPinBody {
-  mobile: string;
-}
-interface SendPinResponse {
-  otp_auth_key: string;
-}
 async function sendPin(body: SendPinBody): Promise<void> {
   const response: SendPinResponse = await client.post("auth/send_pin", body);
   localStorage.setItem(OTP_AUTH_KEY, response.otp_auth_key);
 }
 
-interface VerifyBody {
-  pin: string;
-  otp_auth_key: string;
-}
-interface VerifyResponse {
-  jwt_token: string;
-}
 function verify(body: VerifyBody): Promise<VerifyResponse> {
   return client.post("auth/verify", body);
 }

--- a/src/lib/services/AuthenticationService/types.ts
+++ b/src/lib/services/AuthenticationService/types.ts
@@ -1,0 +1,13 @@
+export interface SendPinBody {
+  mobile: string;
+}
+export interface SendPinResponse {
+  otp_auth_key: string;
+}
+export interface VerifyBody {
+  pin: string;
+  otp_auth_key: string;
+}
+export interface VerifyResponse {
+  jwt_token: string;
+}

--- a/src/pages/Login/Login.test.tsx
+++ b/src/pages/Login/Login.test.tsx
@@ -7,7 +7,7 @@ import { IonButton, IonInput } from "@ionic/react";
 import client from "lib/client/client";
 import { ApiError } from "lib/errors";
 import { clickButton, fillIonInput } from "./test_utils";
-import { OTP_AUTH_KEY } from "config/localStorageKeys";
+import { OTP_AUTH_KEY } from "test-utils/config/localStorageKeys";
 
 test("renders a login title", () => {
   const { container } = render(<Login />, { wrapper: MemoryRouter });

--- a/src/pages/Login/Login.test.tsx
+++ b/src/pages/Login/Login.test.tsx
@@ -198,6 +198,8 @@ describe("On receiving successful API response from send_pin", () => {
   it("should store token in localStorage", async () => {
     const { container } = render(<Login />, { wrapper: MemoryRouter });
 
+    expect(localStorage.getItem(OTP_AUTH_KEY)).toBeNull();
+
     fillIonInput(container, "12345678");
     clickButton(container);
 

--- a/src/pages/Login/Login.test.tsx
+++ b/src/pages/Login/Login.test.tsx
@@ -7,6 +7,7 @@ import { IonButton, IonInput } from "@ionic/react";
 import client from "lib/client/client";
 import { ApiError } from "lib/errors";
 import { clickButton, fillIonInput } from "./test_utils";
+import { OTP_AUTH_KEY } from "config/localStorageKeys";
 
 test("renders a login title", () => {
   const { container } = render(<Login />, { wrapper: MemoryRouter });
@@ -129,11 +130,13 @@ describe("Get SMS PIN button", () => {
 
 describe("On receiving successful API response from send_pin", () => {
   let mockPost: jest.SpyInstance;
+  const otpAuthKey = "fdsfdsfdsfdsffd";
   beforeAll(() => {
     mockPost = jest.spyOn(client, "post").mockResolvedValue({
-      otp_auth_key: "fdsfdsfdsfdsffd",
+      otp_auth_key: otpAuthKey,
     });
   });
+  afterEach(() => localStorage.removeItem(OTP_AUTH_KEY));
   afterAll(() => mockPost.mockRestore());
 
   it("should navigate to /authenticate", async () => {
@@ -178,8 +181,7 @@ describe("On receiving successful API response from send_pin", () => {
       </Router>
     );
 
-    const phoneInput = "12345678";
-    fillIonInput(container, phoneInput);
+    fillIonInput(container, "12345678");
     clickButton(container);
 
     await wait(() => expect(mockHistoryPush).toHaveBeenCalledTimes(1));
@@ -189,6 +191,17 @@ describe("On receiving successful API response from send_pin", () => {
 
     mockHistoryPush.mockRestore();
     mockUseLocation.mockRestore();
+  });
+
+  it("should store token in localStorage", async () => {
+    const { container } = render(<Login />, { wrapper: MemoryRouter });
+
+    fillIonInput(container, "12345678");
+    clickButton(container);
+
+    await wait(() =>
+      expect(localStorage.getItem(OTP_AUTH_KEY)).toBe(otpAuthKey)
+    );
   });
 });
 

--- a/src/pages/Login/Login.test.tsx
+++ b/src/pages/Login/Login.test.tsx
@@ -107,6 +107,8 @@ describe("Get SMS PIN button", () => {
   });
 
   describe("on click", () => {
+    afterEach(() => localStorage.removeItem(OTP_AUTH_KEY));
+
     it("should call auth/send_pin API endpoint with the correct mobile value", () => {
       const mockPost = jest.spyOn(client, "post").mockResolvedValue({
         otp_auth_key: "fdsafdsafds",

--- a/src/test-utils/config/localStorageKeys.ts
+++ b/src/test-utils/config/localStorageKeys.ts
@@ -1,0 +1,4 @@
+const GC_API_TOKEN = "gc_api_token";
+const OTP_AUTH_KEY = "otp_auth_key";
+
+export { GC_API_TOKEN, OTP_AUTH_KEY };


### PR DESCRIPTION
## Ticket Link
https://jira.crossroads.org.hk/browse/GCW-3479
## What does this PR do?
Stores the `otp_auth_token` received from send_pin API response in localStorage.