### PR TITLE
GCW-3581 Add support for VSCode GraphQL extension

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,7 +35,6 @@ android/.idea
 .env.development.local
 .env.test.local
 .env.production.local
-.vscode
 
 npm-debug.log*
 yarn-debug.log*

--- a/.gitignore
+++ b/.gitignore
@@ -35,6 +35,8 @@ android/.idea
 .env.development.local
 .env.test.local
 .env.production.local
+.vscode/*
+!.vscode/extensions.json
 
 npm-debug.log*
 yarn-debug.log*

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,6 @@
+{
+  "recommendations": [
+    "graphql.vscode-graphql",
+    "esbenp.prettier-vscode"
+  ]
+}

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,5 @@
+{
+  "recommendations": [
+    "graphql.vscode-graphql",
+  ]
+}

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,5 +1,6 @@
 {
   "recommendations": [
     "graphql.vscode-graphql",
+    "esbenp.prettier-vscode"
   ]
 }

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,6 +1,0 @@
-{
-  "recommendations": [
-    "graphql.vscode-graphql",
-    "esbenp.prettier-vscode"
-  ]
-}

--- a/codegen.yml
+++ b/codegen.yml
@@ -10,3 +10,6 @@ generates:
       - "typescript"
       - "typescript-operations"
       - "typescript-react-apollo"
+  ./graphql.schema.json:
+    plugins:
+      - "introspection"

--- a/graphql.config.json
+++ b/graphql.config.json
@@ -1,0 +1,4 @@
+{
+  "schema": "graphql.schema.json",
+  "documents": "src/**/*.graphql"
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1592,6 +1592,24 @@
         }
       }
     },
+    "@graphql-codegen/introspection": {
+      "version": "1.18.1",
+      "resolved": "https://registry.npmjs.org/@graphql-codegen/introspection/-/introspection-1.18.1.tgz",
+      "integrity": "sha512-M8kLUYF+YA/oj378RHh7BN5hO2wdplBfL2oyRL9sxjtNY30iYGn7To3TRijDCNoXaak5jLwgwUURZ0BZgX6IJA==",
+      "dev": true,
+      "requires": {
+        "@graphql-codegen/plugin-helpers": "^1.18.2",
+        "tslib": "~2.0.1"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.0.3",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.0.3.tgz",
+          "integrity": "sha512-uZtkfKblCEQtZKBF6EBXVZeQNl82yqtDQdv+eck8u7tdPxjLu2/lp5/uPW+um2tpuxINHWy3GhiccY7QgEaVHQ==",
+          "dev": true
+        }
+      }
+    },
     "@graphql-codegen/plugin-helpers": {
       "version": "1.18.4",
       "resolved": "https://registry.npmjs.org/@graphql-codegen/plugin-helpers/-/plugin-helpers-1.18.4.tgz",

--- a/package.json
+++ b/package.json
@@ -68,7 +68,8 @@
     "husky": "^4.3.5",
     "msw": "^0.25.0",
     "prettier": "2.2.0",
-    "typescript": "^4.1.3"
+    "typescript": "^4.1.3",
+    "@graphql-codegen/introspection": "1.18.1"
   },
   "husky": {
     "hooks": {


### PR DESCRIPTION
## Ticket Link
https://jira.crossroads.org.hk/browse/GCW-3581
## What does this PR do?
Adds support for the VS Code GraphQL extension https://marketplace.visualstudio.com/items?itemName=GraphQL.vscode-graphql which enables auto-completion of graphQL queries.

Also adds config specifying recommended VS Code extensions.