### PR TITLE
GCW-3589 Refactor HasuraClient from singleton to instantiator function

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4,7 +4,7 @@ import { IonReactRouter } from "@ionic/react-router";
 import MainRouter from "components/MainRouter/MainRouter";
 import AuthProvider from "components/AuthProvider/AuthProvider";
 import { ApolloProvider } from "@apollo/client";
-import HasuraClient from "lib/HasuraClient";
+import createHasuraClient from "lib/HasuraClient/createHasuraClient";
 
 /* Core CSS required for Ionic components to work properly */
 import "@ionic/react/css/core.css";
@@ -24,6 +24,8 @@ import "@ionic/react/css/display.css";
 
 /* Theme variables */
 import "theme/variables.css";
+
+const HasuraClient = createHasuraClient();
 
 const App: React.FC = () => {
   return (

--- a/src/lib/HasuraClient/createHasuraClient.ts
+++ b/src/lib/HasuraClient/createHasuraClient.ts
@@ -39,9 +39,10 @@ const errorLink = onError(({ graphQLErrors, operation, forward }) => {
   return forward(operation);
 });
 
-const client = new ApolloClient({
-  link: errorLink.concat(authLink.concat(httpLink)),
-  cache: new InMemoryCache(),
-});
+const createHasuraClient = () =>
+  new ApolloClient({
+    link: errorLink.concat(authLink.concat(httpLink)),
+    cache: new InMemoryCache(),
+  });
 
-export default client;
+export default createHasuraClient;


### PR DESCRIPTION
## Ticket Link
https://jira.crossroads.org.hk/browse/GCW-3589
## What does this PR do?
Singletons make test isolation difficult.
For example, in the following scenario
```
import HasuraClient from "lib/HasuraClient";

test("abc", () => {
  render(
    <ApolloProvider client={HasuraClient}>
      <Offers />
    </ApolloProvider>
  );
  // ...
})

test("xyz", () => {
  render(
    <ApolloProvider client={HasuraClient}>
      <Offers />
    </ApolloProvider>
  );
  // ...
})
```
The effects of the first test would leak into the second test since both tests are referring to the same `HasuraClient` singleton. They would share the same cached values as well as internal private variables which is problematic.

This PR thus refactors the singleton, exporting a function that instantiates the client instead.