### PR TITLE
GCW-3591 Clear hasura token on logout

### DIFF
--- a/src/lib/HasuraClient/createHasuraClient.ts
+++ b/src/lib/HasuraClient/createHasuraClient.ts
@@ -8,10 +8,10 @@ const httpLink = createHttpLink({
   uri: process.env.REACT_APP_HASURA_URL,
 });
 
-const getHasuraToken = throttle(AuthenticationService.getHasuraToken);
+const resolveHasuraToken = throttle(AuthenticationService.resolveHasuraToken);
 
 const authLink = setContext(async (_, { headers }) => {
-  const token = await getHasuraToken();
+  const token = await resolveHasuraToken();
 
   return {
     headers: {

--- a/src/lib/services/AuthenticationService/AuthenticationService.test.ts
+++ b/src/lib/services/AuthenticationService/AuthenticationService.test.ts
@@ -123,6 +123,35 @@ describe("Methods with API calls", () => {
     });
   });
 
+  describe("resolveHasuraToken", () => {
+    beforeEach(() =>
+      mockPost.mockResolvedValue(mockResponse["auth/hasura"].success)
+    );
+
+    describe("User without hasura token", () => {
+      it("should call refresh endpoint", async () => {
+        await AuthenticationService.resolveHasuraToken();
+        expect(mockPost).toHaveBeenCalledTimes(1);
+        expect(mockPost).toHaveBeenCalledWith("auth/hasura", null, {
+          headers: {
+            Authorization: expect.any(String),
+          },
+        });
+      });
+    });
+
+    describe("User with hasura token", () => {
+      beforeEach(async () => {
+        await AuthenticationService.refreshHasuraToken();
+      });
+
+      it("should NOT call refresh endpoint", async () => {
+        await AuthenticationService.resolveHasuraToken();
+        expect(mockPost).not.toHaveBeenCalledWith("auth/hasura");
+      });
+    });
+  });
+
   describe("refreshHasuraToken", () => {
     beforeEach(() =>
       mockPost.mockResolvedValue(mockResponse["auth/hasura"].success)

--- a/src/lib/services/AuthenticationService/AuthenticationService.test.ts
+++ b/src/lib/services/AuthenticationService/AuthenticationService.test.ts
@@ -190,6 +190,22 @@ describe("logout", () => {
     AuthenticationService.logout();
     expect(AuthenticationService.isAuthenticated()).toBe(false);
   });
+
+  it("should clear the hasura token", async () => {
+    const mockPost = jest
+      .spyOn(client, "post")
+      .mockResolvedValue(mockResponse["auth/hasura"].success);
+
+    await AuthenticationService.refreshHasuraToken();
+
+    expect(AuthenticationService.getHasuraToken()).not.toBe(null);
+
+    AuthenticationService.logout();
+
+    expect(AuthenticationService.getHasuraToken()).toBe(null);
+
+    mockPost.mockRestore();
+  });
 });
 
 describe("isAuthenticated", () => {

--- a/src/lib/services/AuthenticationService/AuthenticationService.ts
+++ b/src/lib/services/AuthenticationService/AuthenticationService.ts
@@ -41,7 +41,7 @@ function getHasuraToken(): string | null {
   return hasuraToken;
 }
 
-function setHasuraToken(tokenValue: string) {
+function setHasuraToken(tokenValue: string | null) {
   hasuraToken = tokenValue;
 }
 
@@ -51,7 +51,7 @@ function setHasuraToken(tokenValue: string) {
  */
 async function resolveHasuraToken(): Promise<string> {
   if (!hasuraToken) await AuthenticationService.refreshHasuraToken();
-  return hasuraToken as string;
+  return getHasuraToken() as string;
 }
 
 async function refreshHasuraToken(): Promise<void> {
@@ -65,7 +65,7 @@ async function refreshHasuraToken(): Promise<void> {
 }
 
 function invalidateHasuraToken() {
-  hasuraToken = null;
+  setHasuraToken(null);
 }
 
 const AuthenticationService = {

--- a/src/lib/services/AuthenticationService/AuthenticationService.ts
+++ b/src/lib/services/AuthenticationService/AuthenticationService.ts
@@ -29,6 +29,7 @@ async function authenticate(pin: string): Promise<VerifyResponse> {
 }
 
 function logout() {
+  invalidateHasuraToken();
   localStorage.removeItem(GC_API_TOKEN);
 }
 

--- a/src/lib/services/AuthenticationService/AuthenticationService.ts
+++ b/src/lib/services/AuthenticationService/AuthenticationService.ts
@@ -40,6 +40,12 @@ function isAuthenticated() {
 function setHasuraToken(tokenValue: string) {
   hasuraToken = tokenValue;
 }
+
+/**
+ * Returns the existing hasuraToken
+ * If it is unavailable, fetches a new one and returns that
+ */
+async function resolveHasuraToken(): Promise<string> {
   if (!hasuraToken) await AuthenticationService.refreshHasuraToken();
   return hasuraToken as string;
 }
@@ -63,7 +69,7 @@ const AuthenticationService = {
   authenticate,
   logout,
   isAuthenticated,
-  getHasuraToken,
+  resolveHasuraToken,
   refreshHasuraToken,
   invalidateHasuraToken,
 };

--- a/src/lib/services/AuthenticationService/AuthenticationService.ts
+++ b/src/lib/services/AuthenticationService/AuthenticationService.ts
@@ -37,7 +37,9 @@ function isAuthenticated() {
   return Boolean(localStorage.getItem(GC_API_TOKEN));
 }
 
-async function getHasuraToken(): Promise<string> {
+function setHasuraToken(tokenValue: string) {
+  hasuraToken = tokenValue;
+}
   if (!hasuraToken) await AuthenticationService.refreshHasuraToken();
   return hasuraToken as string;
 }
@@ -49,7 +51,7 @@ async function refreshHasuraToken(): Promise<void> {
       Authorization: gcApiToken ? `Bearer ${gcApiToken}` : "",
     },
   });
-  hasuraToken = response.token;
+  setHasuraToken(response.token);
 }
 
 function invalidateHasuraToken() {

--- a/src/lib/services/AuthenticationService/AuthenticationService.ts
+++ b/src/lib/services/AuthenticationService/AuthenticationService.ts
@@ -37,6 +37,10 @@ function isAuthenticated() {
   return Boolean(localStorage.getItem(GC_API_TOKEN));
 }
 
+function getHasuraToken(): string | null {
+  return hasuraToken;
+}
+
 function setHasuraToken(tokenValue: string) {
   hasuraToken = tokenValue;
 }
@@ -72,6 +76,7 @@ const AuthenticationService = {
   resolveHasuraToken,
   refreshHasuraToken,
   invalidateHasuraToken,
+  getHasuraToken,
 };
 
 export default AuthenticationService;

--- a/src/pages/Offers/Offers.test.tsx
+++ b/src/pages/Offers/Offers.test.tsx
@@ -22,7 +22,7 @@ test("renders correctly", () => {
   expect(container).toMatchSnapshot();
 });
 
-test("clicking log out button should call the logout function", () => {
+test("clicking log out button should log user out", () => {
   render(
     <AuthProvider initialAuthState={true}>
       <TestComponent />


### PR DESCRIPTION
## Ticket Link
https://jira.crossroads.org.hk/browse/GCW-3591
## What does this PR do?
Clear hasura token upon logging out. Otherwise a user who logs out and logs in as a different user would continue querying hasura with the previous user's token.