### PR TITLE
GCW-3592 clear hasura token between tests for test isolation

### DIFF
--- a/src/lib/HasuraClient/createHasuraClient.ts
+++ b/src/lib/HasuraClient/createHasuraClient.ts
@@ -34,7 +34,7 @@ const errorLink = onError(({ graphQLErrors, operation, forward }) => {
   const invalidToken = (graphQLErrors ?? []).find(
     ({ extensions }) => extensions?.code === "invalid-jwt"
   );
-  if (invalidToken) AuthenticationService.invalidateToken();
+  if (invalidToken) AuthenticationService.invalidateHasuraToken();
 
   return forward(operation);
 });

--- a/src/lib/services/AuthenticationService/AuthenticationService.ts
+++ b/src/lib/services/AuthenticationService/AuthenticationService.ts
@@ -51,7 +51,7 @@ async function refreshHasuraToken(): Promise<void> {
   hasuraToken = response.token;
 }
 
-function invalidateToken() {
+function invalidateHasuraToken() {
   hasuraToken = null;
 }
 
@@ -62,7 +62,7 @@ const AuthenticationService = {
   isAuthenticated,
   getHasuraToken,
   refreshHasuraToken,
-  invalidateToken,
+  invalidateHasuraToken,
 };
 
 export default AuthenticationService;

--- a/src/setupTests.ts
+++ b/src/setupTests.ts
@@ -3,5 +3,9 @@
 // expect(element).toHaveTextContent(/react/i)
 // learn more: https://github.com/testing-library/jest-dom
 import "@testing-library/jest-dom/extend-expect";
+import AuthenticationService from "lib/services/AuthenticationService/AuthenticationService";
 
-afterEach(() => localStorage.clear());
+afterEach(() => {
+  localStorage.clear();
+  AuthenticationService.invalidateHasuraToken();
+});


### PR DESCRIPTION
## Ticket Link
https://jira.crossroads.org.hk/browse/GCW-3592
## What does this PR do?
Clears the in-memory `hasuraToken` in order to maintain test isolation.

