### PR TITLE
GCW-3633 Rename donors to chats

### DIFF
--- a/src/components/MainRouter/MainRouter.test.tsx
+++ b/src/components/MainRouter/MainRouter.test.tsx
@@ -64,14 +64,14 @@ describe("Unauthenticated User", () => {
 
   [
     { initialPath: "/home", expectedPage: "login" },
-    { initialPath: "/donors", expectedPage: "login" },
+    { initialPath: "/chats", expectedPage: "login" },
     { initialPath: "/offers", expectedPage: "login" },
     { initialPath: "/login", expectedPage: "login" },
     { initialPath: "/authenticate", expectedPage: "authenticate" },
     { initialPath: "/", expectedPage: "login" },
     { initialPath: "/bad-route", expectedPage: "login" },
     { initialPath: "/home/bad-route", expectedPage: "login" },
-    { initialPath: "/donors/bad-route", expectedPage: "login" },
+    { initialPath: "/chats/bad-route", expectedPage: "login" },
     { initialPath: "/offers/bad-route", expectedPage: "login" },
     { initialPath: "/login/bad-route", expectedPage: "login" },
     { initialPath: "/authenticate/bad-route", expectedPage: "login" },
@@ -90,14 +90,14 @@ describe("Authenticated User", () => {
 
   [
     { initialPath: "/home", expectedPage: "home" },
-    { initialPath: "/donors", expectedPage: "donors" },
+    { initialPath: "/chats", expectedPage: "chats" },
     { initialPath: "/offers", expectedPage: "offers" },
     { initialPath: "/login", expectedPage: "login" },
     { initialPath: "/authenticate", expectedPage: "authenticate" },
     { initialPath: "/", expectedPage: "home" },
     { initialPath: "/bad-route", expectedPage: "home" },
     { initialPath: "/home/bad-route", expectedPage: "home" },
-    { initialPath: "/donors/bad-route", expectedPage: "home" },
+    { initialPath: "/chats/bad-route", expectedPage: "home" },
     { initialPath: "/offers/bad-route", expectedPage: "home" },
     { initialPath: "/login/bad-route", expectedPage: "home" },
     { initialPath: "/authenticate/bad-route", expectedPage: "home" },

--- a/src/components/MainRouter/MainRouter.tsx
+++ b/src/components/MainRouter/MainRouter.tsx
@@ -17,7 +17,7 @@ const MainRouter: React.FC = () => {
       <Route exact path="/authenticate">
         <Authenticate />
       </Route>
-      <PrivateRoute exact path={["/home", "/offers", "/donors"]}>
+      <PrivateRoute exact path={["/home", "/offers", "/chats"]}>
         <MainTabs />
       </PrivateRoute>
       <Redirect to={isAuthenticated ? "/home" : "/login"} />

--- a/src/components/MainTabs/MainTabs.test.tsx
+++ b/src/components/MainTabs/MainTabs.test.tsx
@@ -1,7 +1,6 @@
 import React from "react";
 import { render } from "@testing-library/react";
 import MainTabs from "components/MainTabs/MainTabs";
-import { expectToBeOnPage } from "test-utils/matchers";
 import { createMemoryHistory } from "history";
 import { Router } from "react-router";
 
@@ -37,7 +36,7 @@ test("renders navbar at the bottom of the page", () => {
 
 [
   { tabName: "home", expectedLink: "/home" },
-  { tabName: "donors", expectedLink: "/donors" },
+  { tabName: "chats", expectedLink: "/chats" },
   { tabName: "offers", expectedLink: "/offers" },
 ].forEach(({ tabName, expectedLink }) => {
   describe(`${tabName} tab`, () => {

--- a/src/components/MainTabs/MainTabs.tsx
+++ b/src/components/MainTabs/MainTabs.tsx
@@ -11,7 +11,7 @@ import {
   IonTabs,
 } from "@ionic/react";
 import { home, listOutline, chatbubbleOutline } from "ionicons/icons";
-import Donors from "pages/Donors/Donors";
+import Chats from "pages/Chats/Chats";
 
 const MainTabs = () => (
   <IonTabs>
@@ -19,8 +19,8 @@ const MainTabs = () => (
       <Route exact path="/:tab(offers)">
         <Offers />
       </Route>
-      <Route exact path="/:tab(donors)">
-        <Donors />
+      <Route exact path="/:tab(chats)">
+        <Chats />
       </Route>
       <Route exact path="/:tab(home)">
         <Home />
@@ -31,9 +31,9 @@ const MainTabs = () => (
         <IonIcon icon={home} />
         <IonLabel>Home</IonLabel>
       </IonTabButton>
-      <IonTabButton tab="donors" href="/donors">
+      <IonTabButton tab="chats" href="/chats">
         <IonIcon icon={chatbubbleOutline} />
-        <IonLabel>Donors</IonLabel>
+        <IonLabel>Chats</IonLabel>
       </IonTabButton>
       <IonTabButton tab="offers" href="/offers">
         <IonIcon icon={listOutline} />

--- a/src/components/MainTabs/__snapshots__/MainTabs.test.tsx.snap
+++ b/src/components/MainTabs/__snapshots__/MainTabs.test.tsx.snap
@@ -16,14 +16,14 @@ exports[`renders footer correctly 1`] = `
     </ion-label>
   </ion-tab-button>
   <ion-tab-button
-    href="/donors"
-    tab="donors"
+    href="/chats"
+    tab="chats"
   >
     <ion-icon
       icon="data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' class='ionicon' viewBox='0 0 512 512'><title>Chatbubble</title><path d='M87.49 380c1.19-4.38-1.44-10.47-3.95-14.86a44.86 44.86 0 00-2.54-3.8 199.81 199.81 0 01-33-110C47.65 139.09 140.73 48 255.83 48 356.21 48 440 117.54 459.58 209.85a199 199 0 014.42 41.64c0 112.41-89.49 204.93-204.59 204.93-18.3 0-43-4.6-56.47-8.37s-26.92-8.77-30.39-10.11a31.09 31.09 0 00-11.12-2.07 30.71 30.71 0 00-12.09 2.43l-67.83 24.48a16 16 0 01-4.67 1.22 9.6 9.6 0 01-9.57-9.74 15.85 15.85 0 01.6-3.29z' stroke-linecap='round' stroke-miterlimit='10' class='ionicon-fill-none ionicon-stroke-width'/></svg>"
     />
     <ion-label>
-      Donors
+      Chats
     </ion-label>
   </ion-tab-button>
   <ion-tab-button

--- a/src/pages/Chats/Chats.test.tsx
+++ b/src/pages/Chats/Chats.test.tsx
@@ -3,7 +3,7 @@ import { render, wait } from "@testing-library/react";
 import { CustomerConversationsListQuery } from "generated/graphql";
 import createGoodChatClient from "lib/GoodChatClient/createGoodChatClient";
 import { mockServer } from "mockServer";
-import Donors from "pages/Donors/Donors";
+import Chats from "pages/Chats/Chats";
 import { pageHeader } from "test-utils/matchers";
 import mockGraphQLQueryResponse from "test-utils/mockGraphQLQueryResponse";
 
@@ -48,22 +48,22 @@ test("should render without crashing", () => {
 
   const { container } = render(
     <ApolloProvider client={createGoodChatClient()}>
-      <Donors />
+      <Chats />
     </ApolloProvider>
   );
   expect(container).toBeInTheDocument();
 });
 
-describe("Donors page header", () => {
+describe("Chats page header", () => {
   beforeEach(() => mockConversations(defaultConversations));
 
   pageHeader({
-    title: "Donors",
+    title: "Chats",
     privatePage: true,
     withBackButton: false,
     element: (
       <ApolloProvider client={createGoodChatClient()}>
-        <Donors />
+        <Chats />
       </ApolloProvider>
     ),
   })();
@@ -93,7 +93,7 @@ test("should show a list of conversations", async () => {
 
   const { container } = render(
     <ApolloProvider client={createGoodChatClient()}>
-      <Donors />
+      <Chats />
     </ApolloProvider>
   );
 
@@ -115,7 +115,7 @@ describe("conversation", () => {
 
         const { container } = render(
           <ApolloProvider client={createGoodChatClient()}>
-            <Donors />
+            <Chats />
           </ApolloProvider>
         );
 
@@ -152,7 +152,7 @@ describe("conversation", () => {
 
         const { container } = render(
           <ApolloProvider client={createGoodChatClient()}>
-            <Donors />
+            <Chats />
           </ApolloProvider>
         );
 

--- a/src/pages/Chats/Chats.tsx
+++ b/src/pages/Chats/Chats.tsx
@@ -52,7 +52,7 @@ const ConversationItem: React.FC<ConversationItemProps> = ({
   );
 };
 
-const Donors: React.FC = () => {
+const Chats: React.FC = () => {
   const { logout } = useAuth();
   const { data } = useCustomerConversationsListQuery();
 
@@ -60,7 +60,7 @@ const Donors: React.FC = () => {
     <IonPage>
       <IonHeader>
         <IonToolbar>
-          <IonTitle>Donors</IonTitle>
+          <IonTitle>Chats</IonTitle>
           <IonButtons slot="end">
             <IonButton onClick={logout}>Log out</IonButton>
           </IonButtons>
@@ -87,4 +87,4 @@ const Donors: React.FC = () => {
   );
 };
 
-export default Donors;
+export default Chats;


### PR DESCRIPTION
## Ticket Link
https://jira.crossroads.org.hk/browse/GCW-3633
## What does this PR do?
Renames donors tab to chats, along with the routes (e.g. /donors --> /chats), and components