### PR TITLE
GCW-3637 Load codegen variables from codegen env file

### DIFF
--- a/.env.codegen.sample
+++ b/.env.codegen.sample
@@ -1,0 +1,7 @@
+# Create a `.env.codegen` file based off of this file and fill in the values
+
+# This is the url of the Goodchat GraphQL server
+GOODCHAT_URL=
+# You can get this by logging in to GoodChat App as an admin user and getting the jwt.
+# Note that it MUST be an admin user.
+GOODCITY_ADMIN_JWT=

--- a/.gitignore
+++ b/.gitignore
@@ -35,6 +35,7 @@ android/.idea
 .env.development.local
 .env.test.local
 .env.production.local
+.env.codegen
 .vscode/*
 !.vscode/extensions.json
 

--- a/README.md
+++ b/README.md
@@ -30,22 +30,7 @@ This will start the react app.
 
 We use [GraphQL code generator](https://www.graphql-code-generator.com/) to auto-generate types for use in our application.
 
-Before running the code generator, make sure to set the required environment variables for it. You can infer the variables you need to set from `codegen.yml`.
-
-You will need to set the environment variables for
-
-1. `GOODCHAT_URL`. This is the url of the Goodchat GraphQL server
-2. `GOODCITY_ADMIN_JWT`. You can get this by logging in to GoodChat App as an admin user and getting the jwt. Note that it MUST be an admin user.
-
-To run codegen with these env vars, specify them by prefixing them before `npm run codegen`.
-
-For example:
-
-```bash
-GOODCHAT_URL=http://xyz.com/graphql GOODCITY_ADMIN_JWT=1234 npm run codegen
-```
-
-Note that this applies to any command that runs the codegen script (e.g. `npm run codegen:watch`)
+Before running the code generator, make sure to set the required environment variables for it. You can refer to `.env.codegen.sample`
 
 **Working with types and queries**
 

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "eject": "react-scripts eject",
     "cap:sync": "cap sync",
     "format": "prettier --ignore-path .gitignore --write .",
-    "codegen": "graphql-codegen --config codegen.yml",
+    "codegen": "graphql-codegen --config codegen.yml dotenv_config_path=.env.codegen --require dotenv/config",
     "codegen:watch": "npm run codegen -- --watch"
   },
   "eslintConfig": {


### PR DESCRIPTION
## Ticket Link
https://jira.crossroads.org.hk/browse/GCW-3637
## What does this PR do?
Loads codegen from `.env.codegen` instead of requiring developers to prefix them before running the codegen script every time.