### PR TITLE
Chat message outbox

### DIFF
--- a/.env.toml
+++ b/.env.toml
@@ -15,3 +15,8 @@ REACT_APP_GOODCHAT_URL="https://goodchat-staging-api.azurewebsites.net"
 
 REACT_APP_API_V2_URL="https://api-test.goodcity.hk/api/v2"
 REACT_APP_GOODCHAT_URL="https://goodchat-api-test.net"
+
+[env.development]
+
+REACT_APP_API_V2_URL="http://localhost:3000/api/v2"
+REACT_APP_GOODCHAT_URL="http://localhost:8000"

--- a/graphql.schema.json
+++ b/graphql.schema.json
@@ -946,6 +946,30 @@
                 "defaultValue": null,
                 "isDeprecated": false,
                 "deprecationReason": null
+              },
+              {
+                "name": "timestamp",
+                "description": null,
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "DateTime",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
+              },
+              {
+                "name": "metadata",
+                "description": null,
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "JSON",
+                  "ofType": null
+                },
+                "defaultValue": null,
+                "isDeprecated": false,
+                "deprecationReason": null
               }
             ],
             "type": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -28,6 +28,7 @@
         "graphql": "^15.5.0",
         "history": "^4.10.1",
         "i18next": "^20.3.1",
+        "immutability-helper": "^3.1.1",
         "ionicons": "^5.0.0",
         "kankyo": "^1.6.1",
         "lodash": "^4.17.21",
@@ -11829,6 +11830,11 @@
       "version": "7.0.9",
       "resolved": "https://registry.npmjs.org/immer/-/immer-7.0.9.tgz",
       "integrity": "sha512-Vs/gxoM4DqNAYR7pugIxi0Xc8XAun/uy7AQu4fLLqaTBHxjOP9pJ266Q9MWA/ly4z6rAFZbvViOtihxUZ7O28A=="
+    },
+    "node_modules/immutability-helper": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/immutability-helper/-/immutability-helper-3.1.1.tgz",
+      "integrity": "sha512-Q0QaXjPjwIju/28TsugCHNEASwoCcJSyJV3uO1sOIQGI0jKgm9f41Lvz0DZj3n46cNCyAZTsEYoY4C2bVRUzyQ=="
     },
     "node_modules/immutable": {
       "version": "3.7.6",
@@ -36108,6 +36114,11 @@
       "version": "7.0.9",
       "resolved": "https://registry.npmjs.org/immer/-/immer-7.0.9.tgz",
       "integrity": "sha512-Vs/gxoM4DqNAYR7pugIxi0Xc8XAun/uy7AQu4fLLqaTBHxjOP9pJ266Q9MWA/ly4z6rAFZbvViOtihxUZ7O28A=="
+    },
+    "immutability-helper": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/immutability-helper/-/immutability-helper-3.1.1.tgz",
+      "integrity": "sha512-Q0QaXjPjwIju/28TsugCHNEASwoCcJSyJV3uO1sOIQGI0jKgm9f41Lvz0DZj3n46cNCyAZTsEYoY4C2bVRUzyQ=="
     },
     "immutable": {
       "version": "3.7.6",

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "graphql": "^15.5.0",
     "history": "^4.10.1",
     "i18next": "^20.3.1",
+    "immutability-helper": "^3.1.1",
     "ionicons": "^5.0.0",
     "kankyo": "^1.6.1",
     "lodash": "^4.17.21",

--- a/src/components/Chat/MessageFooter.tsx
+++ b/src/components/Chat/MessageFooter.tsx
@@ -1,4 +1,5 @@
 
+import { IonColor } from "typings/style"
 import { IonNote } from "@ionic/react";
 
 // ---------------------------------
@@ -7,6 +8,7 @@ import { IonNote } from "@ionic/react";
 
 export type MessageFooterProps = {
   align?: 'left' | 'right'
+  color?: IonColor
   text: string
 }
 
@@ -14,7 +16,7 @@ export type MessageFooterProps = {
 // ~ MESSAGE FOOTER
 // ---------------------------------
 
-export const MessageFooter : React.FC<MessageFooterProps> = ({ text, align }) => {
+export const MessageFooter : React.FC<MessageFooterProps> = ({ text, align, color = "light" }) => {
   align = align ?? 'left';
 
   const style = {
@@ -22,7 +24,7 @@ export const MessageFooter : React.FC<MessageFooterProps> = ({ text, align }) =>
   }
 
   return (
-    <IonNote class="chat-message-footer" style={style}>
+    <IonNote class="chat-message-footer" color={color} style={style}>
       <small>{ text }</small>
     </IonNote>
   );

--- a/src/components/Chat/MessageInput.test.tsx
+++ b/src/components/Chat/MessageInput.test.tsx
@@ -1,6 +1,6 @@
 import userEvent, { TargetElement } from "@testing-library/user-event";
 import { ionFireEvent } from "@ionic/react-test-utils";
-import { render, wait, screen } from "@testing-library/react";
+import { render, wait } from "@testing-library/react";
 import MessageInput from "./MessageInput"
 import { act } from "react-dom/test-utils";
 

--- a/src/components/Layout/Sticky.tsx
+++ b/src/components/Layout/Sticky.tsx
@@ -6,7 +6,8 @@ import { style } from 'typestyle'
 // ---------------------------------
 
 export type StickyProps = {
-  position: "top" | "bottom"
+  position: "top" | "bottom",
+  zIndex?: number
 }
 
 // ---------------------------------
@@ -29,9 +30,11 @@ const stickyStyle = style({
 // ~ FLOATING STICKY COMPONENT
 // ---------------------------------
 
-export const Sticky: React.FC<StickyProps> = ({ children, position }) => {
+export const Sticky: React.FC<StickyProps> = ({ children, position, zIndex }) => {
+  const zStyle = zIndex ? { zIndex } : {}
+
   return (
-    <div className={classNames(stickyStyle, position)}>
+    <div className={classNames(stickyStyle, position)} style={zStyle}>
       { children }
     </div>
   );

--- a/src/components/MainRouter/MainRouter.test.tsx
+++ b/src/components/MainRouter/MainRouter.test.tsx
@@ -1,4 +1,6 @@
 import { renderPage } from "test-utils/renderers";
+import * as factories from 'test-utils/factories'
+import { ConversationType } from "generated/graphql";
 
 describe("Unauthenticated User", () => {
   [
@@ -40,7 +42,14 @@ describe("Authenticated User", () => {
     { initialPath: "/authenticate/bad-route",  expectedPath: "/home" },
   ].map(({ initialPath, expectedPath }) => {
     it(`visiting ${initialPath} should be taken to ${expectedPath}`, async () => {
-      const { history } = await renderPage(initialPath)
+      const { history } = await renderPage(initialPath, {
+        disableGlobalResolvers: true,
+        mocks: {
+          Conversation: () => factories.conversationFactory.build({
+            type: ConversationType.Customer
+          })
+        }
+      })
       expect(history.location.pathname).toEqual(expectedPath);
     });
   });

--- a/src/generated/graphql.tsx
+++ b/src/generated/graphql.tsx
@@ -254,6 +254,8 @@ export type Mutation = {
 export type MutationSendMessageArgs = {
   conversationId: Scalars['Int'];
   text: Scalars['String'];
+  timestamp?: Maybe<Scalars['DateTime']>;
+  metadata?: Maybe<Scalars['JSON']>;
 };
 
 
@@ -437,6 +439,7 @@ export type NewMessagesSubSubscription = (
 export type SendMessageMutationVariables = Exact<{
   conversationId: Scalars['Int'];
   text: Scalars['String'];
+  timestamp: Scalars['DateTime'];
 }>;
 
 
@@ -608,8 +611,8 @@ export function useNewMessagesSubSubscription(baseOptions: Apollo.SubscriptionHo
 export type NewMessagesSubSubscriptionHookResult = ReturnType<typeof useNewMessagesSubSubscription>;
 export type NewMessagesSubSubscriptionResult = Apollo.SubscriptionResult<NewMessagesSubSubscription>;
 export const SendMessageDocument = gql`
-    mutation sendMessage($conversationId: Int!, $text: String!) {
-  sendMessage(conversationId: $conversationId, text: $text) {
+    mutation sendMessage($conversationId: Int!, $text: String!, $timestamp: DateTime!) {
+  sendMessage(conversationId: $conversationId, text: $text, timestamp: $timestamp) {
     id
     authorType
     authorId
@@ -635,6 +638,7 @@ export type SendMessageMutationFn = Apollo.MutationFunction<SendMessageMutation,
  *   variables: {
  *      conversationId: // value for 'conversationId'
  *      text: // value for 'text'
+ *      timestamp: // value for 'timestamp'
  *   },
  * });
  */

--- a/src/hooks/useAsync.ts
+++ b/src/hooks/useAsync.ts
@@ -11,7 +11,7 @@ type UseAsyncReturnTuple<T, A extends unknown[]> = [
   execute: (...args: A) => Promise<void>
 ];
 
-const useAsync = <T, A extends unknown[]>(
+export const useAsync = <T, A extends unknown[]>(
   asyncCallback: AsyncCallback<T, A>
 ): UseAsyncReturnTuple<T, A> => {
   const [data, setData] = useState<T | null>(null);

--- a/src/hooks/useLayoutTrigger.ts
+++ b/src/hooks/useLayoutTrigger.ts
@@ -1,0 +1,28 @@
+import { useState, useEffect } from "react"
+
+type EffectFunc = () => any
+type TriggerFunc = () => any
+
+type UseCounterTuple = [TriggerFunc]
+
+/**
+ * Similar to useEffect, except it returns a trigger function used to start up the effect.
+ * Uses a timeout of 0 to trigger the effect post-rendering
+ *
+ * @param {EffectFunc} fn
+ * @returns {UseCounterTuple}
+ */
+ export const useLayoutTrigger = (fn: EffectFunc) : UseCounterTuple => {
+  const [counter, setCounter] = useState(0);
+
+  useEffect(() => {
+    const timeout = setTimeout(fn, 0);
+    return () => clearTimeout(timeout);
+  }, [counter])
+
+  const trigger : TriggerFunc = () => {
+    setCounter(v => v + 1);
+  }
+
+  return [trigger];
+}

--- a/src/hooks/useMessages.ts
+++ b/src/hooks/useMessages.ts
@@ -1,0 +1,290 @@
+import { useEffect, useState } from "react";
+import { useSafeSetState } from "./useSafeSetState"
+import { MessageContent } from "../typings/goodchat"
+import { GraphQLError } from "graphql";
+import { useAsync } from './useAsync'
+import uniqueId from 'lodash/uniqueId'
+import uniqBy from 'lodash/sortedUniqBy'
+import update from 'immutability-helper'
+import {
+  ConversationMessagesQuery,
+  SendMessageMutation,
+  useConversationMessagesQuery,
+  useNewMessagesSubSubscription,
+  useSendMessageMutation,
+} from "../generated/graphql";
+
+// --------------------------------
+// ~ HOOK TYPES
+// --------------------------------
+
+const DEFAULT_PAGE_SIZE = 25;
+
+type Definite<T> = Exclude<T, null | undefined>
+
+type Callback<T = void> = (arg: T) => any
+
+export type ConversationRecord = ConversationMessagesQuery["conversation"]
+
+export type MessageRecord = Definite<ConversationRecord>["messages"][0];
+
+export interface WrappedMessage {
+  uid: string
+  type: "localMessage" | "savedMessage"
+  status: "unsent" | "pending" | "failed" | "saved"
+  content: MessageContent
+  error: Error | null
+  timestamp: Date
+  record?: MessageRecord
+}
+
+export interface SavedMessage extends WrappedMessage {
+  status: 'saved',
+  record: MessageRecord
+}
+
+export type UseMessagesProps = {
+  pageSize?: number
+  lazy?: boolean
+  conversationId: number
+  onComplete?: Callback
+  onNewMessage?: Callback<WrappedMessage>
+}
+
+// --------------------------------
+// ~ HELPERS
+// --------------------------------
+
+const noop = () => {}
+
+// --------------------------------
+// ~ HOOK IMPLEMENTATION
+// --------------------------------
+
+export const useMessages = (props: UseMessagesProps) => {
+  const {
+    pageSize = DEFAULT_PAGE_SIZE,
+    onNewMessage = noop,
+    onComplete = noop,
+    lazy = false,
+    conversationId
+  } = props;
+
+  // ---------------------------------
+  // ~ STATE MANAGEMENT
+  // ---------------------------------
+
+  const [messages, setMessages] = useState<WrappedMessage[]>([]);
+  const [complete, setComplete] = useState(false);
+  const safeSetState = useSafeSetState();
+
+  const addMessages = (newMessages?: WrappedMessage[]) => {
+    if (!newMessages || newMessages.length === 0) return;
+
+    setMessages((msgs) => {
+      return uniqBy(
+        [
+          ...msgs,
+          ...(newMessages || [])
+        ].sort((m1, m2) => {
+          return m1.timestamp.getTime() - m2.timestamp.getTime();
+        }),
+        "uid"
+      )
+    })
+  };
+
+  const updateMessage = (uid: string, data: Partial<WrappedMessage>) => {
+    setMessages((messages) => {
+      const index = messages.findIndex((om) => om.uid === uid);
+      if (index >= 0) {
+        const wrappedMessage = messages[index];
+        const updatedMessage : WrappedMessage = {
+          ...wrappedMessage,
+          ...data
+        }
+        return update(messages, { $splice: [[index, 1, updatedMessage]] });
+      }
+      return messages;
+    })
+  }
+
+  const removeMessage = (uid: string) => {
+    setMessages((messages) => {
+      const index = messages.findIndex((om) => om.uid === uid);
+      if (index >= 0) {
+        return update(messages, { $splice: [[index, 1]] });
+      }
+      return messages;
+    });
+  }
+
+  const wrapMessage = (message: MessageRecord) : SavedMessage => {
+    return {
+      uid: `saved-${message.id}`,
+      type: 'savedMessage',
+      status: "saved",
+      content: message?.content,
+      error: null,
+      timestamp: new Date(message.createdAt),
+      record: message
+    }
+  }
+
+  // ---------------------------------
+  // ~ DATA READ/WRITE
+  // ---------------------------------
+
+  const [postMessage] = useSendMessageMutation();
+
+  const { refetch } = useConversationMessagesQuery({ skip: true });
+
+  const { error: subscriptionError } = useNewMessagesSubSubscription({
+    variables: { conversationId: Number(conversationId) },
+    onSubscriptionData: ({ subscriptionData }) => {
+      const message = subscriptionData.data?.messageEvent?.message
+
+      if (!message) return;
+
+      const wrapper = wrapMessage(message);
+
+      addMessages([wrapper]);
+      onNewMessage(wrapper)
+    }
+  });
+
+  // ---------------------------------
+  // ~ HOOK API
+  // ---------------------------------
+
+  //
+  // We expose a loadMore method allowing the caller to fetch another page of data
+  //
+  const [, error, loading, loadMore] = useAsync(async () => {
+    const oldestMessage = messages[0];
+    const cursor = oldestMessage?.record?.id || 0
+
+    const { data } = await refetch({
+      conversationId: Number(conversationId),
+      limit: pageSize,
+      after: cursor,
+    })
+
+    const records = data?.conversation?.messages;
+
+    if (Array.isArray(records)) {
+      addMessages(records.map(wrapMessage));
+
+      // Notify last page was loaded
+      if (!complete && records.length < pageSize) {
+        setComplete(true);
+        onComplete();
+      }
+    }
+  })
+
+  /**
+   * Tries to send an unsent or failed outbox message
+   *
+   * @param {WrappedMessage} wrappedMessage
+   * @returns
+   */
+  const pushMessage = async (wrappedMessage: WrappedMessage) => {
+    const { status, uid } = wrappedMessage;
+
+    if (status === "pending") return;
+
+    if (wrappedMessage.content.type !== 'text') return; // @TODO support other content types
+
+    // 1. Update the state to pending
+    updateMessage(uid, { status: "pending" })
+
+    let error : GraphQLError;
+    let data  : SendMessageMutation
+
+    try {
+      // 2. Trigger the mutation
+      const result = await postMessage({
+        variables: {
+          timestamp: new Date(wrappedMessage.timestamp),
+          conversationId: Number(conversationId),
+          text: wrappedMessage.content.text
+        }
+      })
+
+      if (result?.errors?.length) {
+        error = result.errors[0];
+      }
+
+      if (result.data) {
+        data = result.data
+      }
+    } catch (e) {
+      error = e;
+    }
+
+    // 3. Update the state upon completion of request
+    safeSetState(() => {
+      if (error || !data?.sendMessage) {
+        // 3.1: Mark the local message as 'failed' if an error occurs
+        return updateMessage(uid, {
+          status: 'failed',
+          error: error
+        })
+      }
+
+      // 3.1: Remove the local message and add the real one to the list
+      removeMessage(uid);
+      addMessages([wrapMessage(data.sendMessage)]);
+    })
+  }
+
+  /**
+   * Adds a new message to the list and tries to send it
+   *
+   * @param {string} text
+   */
+  const createMessage = (text: string) => {
+    // 1: Create a local offline message
+    const uid = `local-${uniqueId()}`;
+    const outboxMessage : WrappedMessage = {
+      uid: uid,
+      type: "localMessage",
+      status: "unsent",
+      error: null,
+      timestamp: new Date(),
+      content: {
+        type: "text",
+        text: text
+      }
+    }
+
+    // 2: Add it to the list of messages (it'll appear as unsent at first)
+    addMessages([outboxMessage])
+    onNewMessage(outboxMessage)
+
+    // 3: Send it to the server
+    pushMessage(outboxMessage);
+  }
+
+  // ---------------------------------
+  // ~ LIFECYCLE
+  // ---------------------------------
+
+  useEffect(() => {
+    // Auto-trigger the first page load
+    if (!lazy) { loadMore(); }
+  }, [])
+
+  return {
+    loading,
+    messages,
+    loadMore,
+    complete,
+    createMessage,
+    retry: pushMessage,
+    error: error || subscriptionError || null
+  }
+}
+
+export default useMessages;

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -1,4 +1,10 @@
 {
+  "error": {
+    "generic": "Something went wrong",
+    "actions": {
+      "reload": "Reload"
+    }
+  },
   "home": {
     "title": "Home"
   },
@@ -7,6 +13,13 @@
       "anonymous": "Anonymous",
       "memberCount": "{{memberCount}} member",
       "memberCount_plural": "{{memberCount}} members"
+    },
+    "message": {
+      "status": {
+        "pending": "Pending",
+        "failed": "Failed",
+        "unsent": "Unsent"
+      }
     }
   },
   "chats": {

--- a/src/lib/AutoMockedProvider/createAutoMockedProvider.tsx
+++ b/src/lib/AutoMockedProvider/createAutoMockedProvider.tsx
@@ -8,6 +8,7 @@ import { SchemaLink } from "@apollo/client/link/schema";
 interface AutoMockedProviderProps {
   children: React.ReactNode | React.ReactNode[] | null;
   mockResolvers?: IMocks;
+  disableGlobalResolvers?: boolean
 }
 
 const createAutoMockedProvider = (
@@ -17,12 +18,18 @@ const createAutoMockedProvider = (
   const AutoMockedProvider: React.FC<AutoMockedProviderProps> = ({
     children,
     mockResolvers = {},
+    disableGlobalResolvers = false,
   }) => {
-    const schema = makeExecutableSchema({ typeDefs });
+    const schema = makeExecutableSchema({
+      typeDefs
+    });
     const schemaWithMocks = addMocksToSchema({
       schema,
       // Merge global and local mock resolvers
-      mocks: mergeResolvers([globalMockResolvers, mockResolvers]),
+      mocks: mergeResolvers([
+        disableGlobalResolvers ? {} : globalMockResolvers,
+        mockResolvers
+      ])
     });
 
     const client = new ApolloClient({

--- a/src/pages/Chat/Chat.tsx
+++ b/src/pages/Chat/Chat.tsx
@@ -163,7 +163,7 @@ const Chat: React.FC = () => {
 
       {
         /* Error Banner */
-        error &&
+        error && (
           <IonItem color="danger">
             <span className="ion-margin"> { t('error.generic') }</span>
             <IonButton
@@ -172,6 +172,7 @@ const Chat: React.FC = () => {
               onClick={() => window.location.reload()}
             >{ t('error.actions.reload') }</IonButton>
           </IonItem>
+        )
       }
 
       {/* Main Content */}
@@ -190,12 +191,13 @@ const Chat: React.FC = () => {
           {messages.map((m) => {
             const side = m.record?.authorType === AuthorType.CUSTOMER ? "start" : "end"
             const footer = m.status === 'saved' ? getMessageTime(m) : t(`chat.message.status.${m.status}`)
+            const failed = m.status === 'failed';
 
             return (
               <IonItem key={m.uid} lines={"none"}>
                 <Message slot={side}>
                   <MessageBody content={m.content}></MessageBody>
-                  <MessageFooter text={footer}></MessageFooter>
+                  <MessageFooter text={footer} color={failed ? 'danger' : 'light'}></MessageFooter>
                 </Message>
               </IonItem>
             )

--- a/src/pages/Chat/sendMessage.gql
+++ b/src/pages/Chat/sendMessage.gql
@@ -1,5 +1,5 @@
-mutation sendMessage($conversationId: Int!, $text: String!) {
-  sendMessage(conversationId: $conversationId, text: $text) {
+mutation sendMessage($conversationId: Int!, $text: String!, $timestamp: DateTime!) {
+  sendMessage(conversationId: $conversationId, text: $text, timestamp: $timestamp) {
     id
     authorType
     authorId

--- a/src/test-utils/components/GoodChatMockedProvider/GoodChatMockedProvider.tsx
+++ b/src/test-utils/components/GoodChatMockedProvider/GoodChatMockedProvider.tsx
@@ -1,6 +1,6 @@
 import { printSchema, buildClientSchema } from "graphql/utilities";
-import createAutoMockedProvider from "lib/AutoMockedProvider/createAutoMockedProvider";
-import introspectionResult from "../../../../graphql.schema.json";
+import createAutoMockedProvider from "lib/AutoMockedProvider/createAutoMockedProvider"
+import introspectionResult from "../../../../graphql.schema.json"
 
 const typeDefs = printSchema(buildClientSchema(introspectionResult as any));
 
@@ -9,6 +9,7 @@ const globalMockResolvers = {
     type: "text",
     text: "I want to donate",
   }),
+  DateTime: () => new Date()
 };
 
 const GoodChatMockedProvider = createAutoMockedProvider(

--- a/src/test-utils/renderers.tsx
+++ b/src/test-utils/renderers.tsx
@@ -30,7 +30,8 @@ export async function renderWithAct(
 export type RenderPageOptions = {
   mocks? : IMocks
   authenticated?: boolean,
-  history?: string[]
+  history?: string[],
+  disableGlobalResolvers?: boolean
 }
 
 /**
@@ -50,7 +51,10 @@ export async function renderPage(path: string, opts : RenderPageOptions = {}) {
   const renderResult = await renderWithAct(
     <I18nextProvider i18n={i18n}>
       <AuthProvider initialAuthState={opts.authenticated ?? true}>
-        <GoodChatMockedProvider mockResolvers={opts.mocks || {}}>
+        <GoodChatMockedProvider
+          mockResolvers={opts.mocks || {}}
+          disableGlobalResolvers={opts.disableGlobalResolvers}
+        >
           <Router history={history}>
             <MainRouter />
           </Router>

--- a/src/typings/style.ts
+++ b/src/typings/style.ts
@@ -1,0 +1,12 @@
+
+export type IonColor = (
+  "primary"
+  | "secondary"
+  | "tertiary"
+  | "success"
+  | "warning"
+  | "danger"
+  | "light"
+  | "medium"
+  | "dark"
+)


### PR DESCRIPTION
Changes:

- Messages are immediately added to the list after pressing enter, their "status" will update depending on whether they were successfully sent or not
- Sending messages sets the timestamp, allowing to keep the order of messages even if they fail
- message logic moved to `useMessages` hook
- Fixed issue on iOS where text input was blinking